### PR TITLE
improve hook props types definition

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useCallback } from "react";
+import { DependencyList, useEffect, useCallback } from "react";
 
 const setsEqual = (setA: Set<string>, setB: Set<string>): boolean =>
   setA.size === setB.size && !Array.from(setA).some(v => !setB.has(v));
 
-export const useShortcuts = (keys: string[], callback: () => void, deps: Array<any>) => {
+export const useShortcuts = (keys: ReadonlyArray<string>, callback: () => void, deps: DependencyList) => {
   const memoizedCallback = useCallback(callback, deps || []);
   const targetKeys: Set<string> = new Set(keys.map(key => key.toLowerCase()));
   const pressedKeys: Set<string> = new Set();

--- a/src/useShortcuts.test.tsx
+++ b/src/useShortcuts.test.tsx
@@ -2,7 +2,8 @@ import React from "react"
 import { render, fireEvent } from '@testing-library/react'
 import { useShortcuts } from '.'
 
-const TestComponent = ({ shortcut }) => {
+type TestComponentProps = { shortcut: ReadonlyArray<string> };
+const TestComponent = ({ shortcut }: TestComponentProps) => {
   const [value, setValue] = React.useState(0)
   useShortcuts(shortcut, () => setValue(value + 1), [value])
 


### PR DESCRIPTION
I've made two changes in this PR, both related to types:

1. Use `ReadonlyArray<string>` instead of `string[]` because it allows to pass `['a'] as const` as prop.
2. Use `DependencyList` type to `deps` This isn't needed, but simplifies to be consistent with [`useCallback` props](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L898), which uses `ReadonlyArray` too.

